### PR TITLE
RequestInterface->getParam() can return null.

### DIFF
--- a/src/Interfaces/RequestInterface.php
+++ b/src/Interfaces/RequestInterface.php
@@ -10,7 +10,7 @@ interface RequestInterface
      * @param string $key
      * @param string|null $default
      *
-     * @return string
+     * @return string|null
      */
-    public function getParam(string $key, string $default = null): string;
+    public function getParam(string $key, string $default = null): ?string;
 }


### PR DESCRIPTION
There are cases when we might ask for a param that doesn't exist and default value is not assigned. In such cases, we should return null rather than empty string.